### PR TITLE
Update valve for tomcat 7

### DIFF
--- a/src/org/lemonLDAPNG/SSOValve.java
+++ b/src/org/lemonLDAPNG/SSOValve.java
@@ -90,8 +90,7 @@ public class SSOValve extends ValveBase {
 						roles.add(role);
 				}
 				if (user != null) {
-					request.setUserPrincipal(new GenericPrincipal(this
-							.getContainer().getRealm(), user, "", roles));
+					request.setUserPrincipal(new GenericPrincipal(user, "", roles));
 				} else if (!passThrough) {
 					if (log.isDebugEnabled())
 						log.debug("PassThrough disable, send 403 error");


### PR DESCRIPTION
In Tomcat 7 Principal's constructor doesn't require realm. I update the instruction new GenericPrincipal in consequences.
